### PR TITLE
Ensure vendor type is lowercased when interpreting mask stage

### DIFF
--- a/datasource/src/main/scala/quasar/plugin/avalanche/datasource/MaskInterpreter.scala
+++ b/datasource/src/main/scala/quasar/plugin/avalanche/datasource/MaskInterpreter.scala
@@ -49,7 +49,7 @@ private[datasource] object MaskInterpreter {
       : ConnectionIO[Map[ColumnName, ColumnType.Scalar]] =
     discovery.tableColumns(table.asIdent, schema.map(_.asIdent))
       .map(m =>
-        Types.AvalancheColumnTypes.get(m.vendorType)
+        Types.AvalancheColumnTypes.get(m.vendorType.toLowerCase)
           .orElse(Types.JdbcColumnTypes.get(m.jdbcType))
           .tupleLeft(m.name))
       .unNone


### PR DESCRIPTION
We normalize the vendor specific type names we support by lowercasing them, but we weren't comparing against lowercased values when interpreting the mask stage, causing us to treat the columns as undefined since we couldn't find a supported type.

[ch11818]